### PR TITLE
Coupling kinematic default degrees of freedom

### DIFF
--- a/src/allocation.f
+++ b/src/allocation.f
@@ -1504,11 +1504,15 @@ c     !
           nboun_=nboun_+3*numnodes
         endif
 !     
+        ibounstart=0
         do
           call getnewline(inpc,textpart,istat,n,key,iline,ipol,inl,
      &         ipoinp,inp,ipoinpc)
-          if((istat.lt.0).or.(key.eq.1)) exit
-!     
+          if((istat.lt.0).or.(key.eq.1)) then
+            if(ibounstart.gt.0) exit
+            ibounstart=1
+            ibounend=3
+          else
           read(textpart(1)(1:10),'(i10)',iostat=istat) ibounstart
           if(istat.gt.0) then
             call inputerror(inpc,ipoinpc,iline,
@@ -1526,6 +1530,7 @@ c     !
               exit
             endif
           endif
+          endif
           ibound=ibounend-ibounstart+1
           ibound=max(1,ibound)
           ibound=min(3,ibound)
@@ -1539,6 +1544,7 @@ c     !
             nmpc_=nmpc_+ibound*numnodes
             memmpc_=memmpc_+ibound*6*numnodes
           endif
+          if((istat.lt.0).or.(key.eq.1)) exit
         enddo
       elseif(textpart(1)(1:21).eq.'*MAGNETICPERMEABILITY') then
         ntmatl=0

--- a/src/allocation.f
+++ b/src/allocation.f
@@ -659,7 +659,7 @@ c        itranslation=0
           read(textpart(1)(1:10),'(i10)',iostat=istat) ibounstart
           if(istat.gt.0) then
             call inputerror(inpc,ipoinpc,iline,
-     &           "*BOUNDARY%",ier)
+     &           "*DISTRIBUTING%",ier)
             exit
           endif
 !     
@@ -669,7 +669,7 @@ c        itranslation=0
             read(textpart(2)(1:10),'(i10)',iostat=istat) ibounend
             if(istat.gt.0) then
               call inputerror(inpc,ipoinpc,iline,
-     &             "*BOUNDARY%",ier)
+     &             "*DISTRIBUTING%",ier)
               exit
             endif
           endif
@@ -1512,7 +1512,7 @@ c     !
           read(textpart(1)(1:10),'(i10)',iostat=istat) ibounstart
           if(istat.gt.0) then
             call inputerror(inpc,ipoinpc,iline,
-     &           "*BOUNDARY%",ier)
+     &           "*KINEMATIC%",ier)
             exit
           endif
 !     
@@ -1522,7 +1522,7 @@ c     !
             read(textpart(2)(1:10),'(i10)',iostat=istat) ibounend
             if(istat.gt.0) then
               call inputerror(inpc,ipoinpc,iline,
-     &             "*BOUNDARY%",ier)
+     &             "*KINEMATIC%",ier)
               exit
             endif
           endif

--- a/src/allocation.f
+++ b/src/allocation.f
@@ -1513,23 +1513,23 @@ c     !
             ibounstart=1
             ibounend=3
           else
-          read(textpart(1)(1:10),'(i10)',iostat=istat) ibounstart
-          if(istat.gt.0) then
-            call inputerror(inpc,ipoinpc,iline,
-     &           "*KINEMATIC%",ier)
-            exit
-          endif
-!     
-          if(textpart(2)(1:1).eq.' ') then
-            ibounend=ibounstart
-          else
-            read(textpart(2)(1:10),'(i10)',iostat=istat) ibounend
+            read(textpart(1)(1:10),'(i10)',iostat=istat) ibounstart
             if(istat.gt.0) then
               call inputerror(inpc,ipoinpc,iline,
      &             "*KINEMATIC%",ier)
               exit
             endif
-          endif
+!     
+            if(textpart(2)(1:1).eq.' ') then
+              ibounend=ibounstart
+            else
+              read(textpart(2)(1:10),'(i10)',iostat=istat) ibounend
+              if(istat.gt.0) then
+                call inputerror(inpc,ipoinpc,iline,
+     &               "*KINEMATIC%",ier)
+                exit
+              endif
+            endif
           endif
           ibound=ibounend-ibounstart+1
           ibound=max(1,ibound)

--- a/src/couplings.f
+++ b/src/couplings.f
@@ -405,48 +405,48 @@
             ibounstart=1
             ibounend=3
           else
-          read(textpart(1)(1:10),'(i10)',iostat=istat) ibounstart
-          if(istat.gt.0) then
-            call inputerror(inpc,ipoinpc,iline,
-     &           "*KINEMATIC%",ier)
-            return
-          endif
-          if(ibounstart.lt.1) then
-            write(*,*) '*ERROR reading *KINEMATIC'
-            write(*,*) '       starting degree of freedom cannot'
-            write(*,*) '       be less than 1'
-            write(*,*) '  '
-            call inputerror(inpc,ipoinpc,iline,
-     &           "*KINEMATIC%",ier)
-            return
-          endif
-!     
-          if(textpart(2)(1:1).eq.' ') then
-            ibounend=ibounstart
-          else
-            read(textpart(2)(1:10),'(i10)',iostat=istat) ibounend
+            read(textpart(1)(1:10),'(i10)',iostat=istat) ibounstart
             if(istat.gt.0) then
               call inputerror(inpc,ipoinpc,iline,
      &             "*KINEMATIC%",ier)
               return
             endif
-          endif
-          if(ibounend.gt.3) then
-            write(*,*) '*WARNING reading *KINEMATIC'
-            write(*,*) '       resetting final degree of freedom'
-            write(*,*) '       to its maximum allowed value of 3'
-            write(*,*) '  '
-            ibounend=3
-          endif
-          if(ibounend.lt.ibounstart) then
-            write(*,*) '*ERROR reading *KINEMATIC'
-            write(*,*) '       initial degree of freedom cannot'
-            write(*,*) '       exceed final degree of freedom'
-            write(*,*) '  '
-            call inputerror(inpc,ipoinpc,iline,
-     &           "*KINEMATIC%",ier)
-            return
-          endif
+            if(ibounstart.lt.1) then
+              write(*,*) '*ERROR reading *KINEMATIC'
+              write(*,*) '       starting degree of freedom cannot'
+              write(*,*) '       be less than 1'
+              write(*,*) '  '
+              call inputerror(inpc,ipoinpc,iline,
+     &             "*KINEMATIC%",ier)
+              return
+            endif
+!     
+            if(textpart(2)(1:1).eq.' ') then
+              ibounend=ibounstart
+            else
+              read(textpart(2)(1:10),'(i10)',iostat=istat) ibounend
+              if(istat.gt.0) then
+                call inputerror(inpc,ipoinpc,iline,
+     &               "*KINEMATIC%",ier)
+                return
+              endif
+            endif
+            if(ibounend.gt.3) then
+              write(*,*) '*WARNING reading *KINEMATIC'
+              write(*,*) '       resetting final degree of freedom'
+              write(*,*) '       to its maximum allowed value of 3'
+              write(*,*) '  '
+              ibounend=3
+            endif
+            if(ibounend.lt.ibounstart) then
+              write(*,*) '*ERROR reading *KINEMATIC'
+              write(*,*) '       initial degree of freedom cannot'
+              write(*,*) '       exceed final degree of freedom'
+              write(*,*) '  '
+              call inputerror(inpc,ipoinpc,iline,
+     &             "*KINEMATIC%",ier)
+              return
+            endif
           endif
 !     
 !     generating the MPCs

--- a/src/couplings.f
+++ b/src/couplings.f
@@ -170,7 +170,7 @@
 !     
       if(name(1:1).eq.' ') then
         write(*,*)
-     &       '*ERROR reading *COUPLING: no CONTRAINT NAME given'
+     &       '*ERROR reading *COUPLING: no CONSTRAINT NAME given'
         write(*,*) '  '
         call inputerror(inpc,ipoinpc,iline,
      &       "*COUPLING%",ier)
@@ -423,7 +423,7 @@
             read(textpart(2)(1:10),'(i10)',iostat=istat) ibounend
             if(istat.gt.0) then
               call inputerror(inpc,ipoinpc,iline,
-     &             "*BOUNDARY%",ier)
+     &             "*KINEMATIC%",ier)
               return
             endif
           endif

--- a/src/couplings.f
+++ b/src/couplings.f
@@ -428,14 +428,13 @@
             endif
           endif
           if(ibounend.gt.3) then
-            write(*,*) '*ERROR reading *KINEMATIC'
-            write(*,*) '       final degree of freedom cannot'
-            write(*,*) '       exceed 3'
+            write(*,*) '*WARNING reading *KINEMATIC'
+            write(*,*) '       resetting final degree of freedom'
+            write(*,*) '       to its maximum allowed value of 3'
             write(*,*) '  '
-            call inputerror(inpc,ipoinpc,iline,
-     &           "*KINEMATIC%",ier)
-            return
-          elseif(ibounend.lt.ibounstart) then
+            ibounend=3
+          endif
+          if(ibounend.lt.ibounstart) then
             write(*,*) '*ERROR reading *KINEMATIC'
             write(*,*) '       initial degree of freedom cannot'
             write(*,*) '       exceed final degree of freedom'

--- a/src/couplings.f
+++ b/src/couplings.f
@@ -396,11 +396,15 @@
 !     
 !     reading the degrees of freedom
 !     
+        ibounstart=0
         do
           call getnewline(inpc,textpart,istat,n,key,iline,ipol,inl,
      &         ipoinp,inp,ipoinpc)
-          if((istat.lt.0).or.(key.eq.1)) return
-!     
+          if((istat.lt.0).or.(key.eq.1)) then
+            if(ibounstart.gt.0) return
+            ibounstart=1
+            ibounend=3
+          else
           read(textpart(1)(1:10),'(i10)',iostat=istat) ibounstart
           if(istat.gt.0) then
             call inputerror(inpc,ipoinpc,iline,
@@ -443,6 +447,7 @@
      &           "*KINEMATIC%",ier)
             return
           endif
+          endif
 !     
 !     generating the MPCs
 !     
@@ -472,6 +477,7 @@
      &             iorientation)
             enddo
           endif
+          if((istat.lt.0).or.(key.eq.1)) return
         enddo
       elseif(textpart(1)(2:13).eq.'DISTRIBUTING') then
         if(surfkind.eq.'S') then

--- a/src/couplings.f
+++ b/src/couplings.f
@@ -962,11 +962,18 @@ c        write(*,*) e1(1)*e2(1)+e1(2)*e2(2)+e1(3)*e2(3)
 !
 !     reading the degrees of freedom
 !     
+        ibounstart=0
         do
           call getnewline(inpc,textpart,istat,n,key,iline,ipol,inl,
      &         ipoinp,inp,ipoinpc)
-          if((istat.lt.0).or.(key.eq.1)) return
-!     
+          if((istat.lt.0).or.(key.eq.1)) then
+            if(ibounstart.gt.0) return
+            write(*,*) '*ERROR reading *DISTRIBUTING'
+            write(*,*) '       degrees of freedom must be specified'
+            write(*,*) '  '
+            ier=1
+            return
+          endif
           read(textpart(1)(1:10),'(i10)',iostat=istat) ibounstart
           if(istat.gt.0) then
             call inputerror(inpc,ipoinpc,iline,


### PR DESCRIPTION
In ccx version 2.22 this syntax will silently ignore the *Coupling without error nor warning and without making any MPC:
```abaqus
*Coupling, constraint name=c1, surface=s1, ref node=1
*Kinematic
```
In Abaqus the above syntax will use all degrees of freedom for the rigid coupling. This pull request will replicate the Abaqus behavior when there are no degrees of freedom listed below *Kinematic.

I've also fixed a few typos related to *Coupling (mislabeled errors) and added a new error if degrees of freedom are missing for *Distributing. I didn't want to add default degrees of freedom for *Distributing because the behavior of this coupling is already different from Abaqus.

Thanks for your consideration!