### PR TITLE
Update headings.f: parameter nentries=19

### DIFF
--- a/src/allocation.f
+++ b/src/allocation.f
@@ -2588,7 +2588,7 @@ c     !
           if((istat.lt.0).or.(key.eq.1)) exit
           ntmatl=ntmatl+1
           ntmat_=max(ntmatl,ntmat_)
-          do i=2,nconstants/8+1
+          do i=2, int((nconstants-1)/8)+1
             call getnewline(inpc,textpart,istat,n,key,iline,ipol,
      &           inl,ipoinp,inp,ipoinpc)
           enddo

--- a/src/headings.f
+++ b/src/headings.f
@@ -31,6 +31,8 @@
       integer istat,n,key,iline,ipol,inl,ipoinp(2,*),inp(3,*),
      &  ipoinpc(0:*),i,j,nentries,nheading,istep,irstrt(*),ier
 !
+      parameter(nentries=19)
+
       if((istep.gt.0).and.(irstrt(1).ge.0)) then
          write(*,*) '*ERROR reading *HEADING: *HEADING should be placed'
          write(*,*) '       before all step definitions'

--- a/src/usermaterials.f
+++ b/src/usermaterials.f
@@ -83,7 +83,7 @@
 !
          do
             isum=0
-            do j=1,(nconstants)/8+1
+            do j=1, int((nconstants-1)/8)+1
                if(j.eq.1) then
                   call getnewline(inpc,textpart,istat,n,key,iline,ipol,
      &                 inl,ipoinp,inp,ipoinpc)


### PR DESCRIPTION

[headings_20250411.zip](https://github.com/user-attachments/files/19708981/headings_20250411.zip)
added line "parameter(nentries=19)" because variable nentries is being declared and used, but not initialized in subroutine headings(). With this change variable nentries is being set as a parameter as in all other files where this variable is being used.