### PR TITLE
Squashed commit of the following:

### DIFF
--- a/src/CalculiX.c
+++ b/src/CalculiX.c
@@ -1573,7 +1573,7 @@ int main(int argc,char *argv[])
 		   &nobject,&objectset,&istat,orname,nzsprevstep,&nlabel,
 		   physcon,
 		   jobnamef,iponor,knor,&ne2d,iponoel2d,inoel2d,&mpcend,
-		   dgdxglob,g0,&nodedesi,&ndesi,&nobjectstart,&xdesi,rig);
+		   dgdxglob,g0,&nodedesi,&ndesi,&nobjectstart,&xdesi,rig,fei);
     
       }else{
         sensi_orien(co,&nk,&kon,&ipkon,&lakon,&ne,nodeboun,ndirboun,

--- a/src/CalculiX.h
+++ b/src/CalculiX.h
@@ -4663,7 +4663,7 @@ void sensi_coor(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
              char *jobnamef,ITG *iponor2d,ITG *knor2d,ITG *ne2d,
              ITG *iponoel2d,ITG *inoel2d,ITG *mpcend,
 	     double *dgdxglob,double *g0,ITG **nodedesip,ITG*ndesi,
-	     ITG *nobjectstart,double **xdesip,ITG *rig);
+	     ITG *nobjectstart,double **xdesip,ITG *rig,double *fei);
 
 void sensi_orien(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
              ITG *ne,

--- a/src/CalculiXstep.c
+++ b/src/CalculiXstep.c
@@ -1715,7 +1715,7 @@ void CalculiXstep(int argc,char argv[][133],ITG **nelemloadp,double **xloadp,
 		   &nobject,&objectset,&istat,orname,nzsprevstep,nlabel,
 		   physcon,
 		   jobnamef,iponor,knor,&ne2d,iponoel,inoel,&mpcend,dgdxglob,
-		   g0,&nodedesi,&ndesi,&nobjectstart,&xdesi,rig);
+		   g0,&nodedesi,&ndesi,&nobjectstart,&xdesi,rig,fei);
     
       }else{
         sensi_orien(co,nk,&kon,&ipkon,&lakon,ne,nodeboun,ndirboun,

--- a/src/sensi_coor.c
+++ b/src/sensi_coor.c
@@ -60,7 +60,8 @@ void sensi_coor(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
 		ITG *nzsprevstep,ITG *nlabel,double *physcon,char *jobnamef,
 		ITG *iponor2d,ITG *knor2d,ITG *ne2d,ITG *iponoel2d,ITG *inoel2d,
 		ITG *mpcend,double *dgdxglob,double *g0,ITG **nodedesip,
-		ITG *ndesi,ITG *nobjectstart,double **xdesip,ITG *rig){
+		ITG *ndesi,ITG *nobjectstart,double **xdesip,ITG *rig,
+		double *fei){
 	     
   char description[13]="            ",*lakon=NULL,cflag[1]=" ",fneig[132]="",
     stiffmatrix[132]="",*lakonfa=NULL,*objectset=NULL;
@@ -100,7 +101,7 @@ void sensi_coor(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
     distmin,*df=NULL,*dgdx=NULL,sigma=0,*extnor=NULL,*veold=NULL,
     *accold=NULL,bet,gam,sigmak=1.,sigmal=1.,dtime,time,reltime=1.,
     *fint=NULL,*xnor=NULL,*dgdxdy=NULL,*x=NULL,*y=NULL,*xo=NULL,*yo=NULL,
-    *zo=NULL,*dist=NULL,*dummy=NULL;
+    *zo=NULL,*dist=NULL,*dummy=NULL,fmin,fmax,pi;
 
   FILE *f1;
   
@@ -112,6 +113,8 @@ void sensi_coor(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
   kon=*konp;ielmat=*ielmatp;ielorien=*ielorienp;objectset=*objectsetp;
   nodedesi=*nodedesip;xdesi=*xdesip;
 
+  pi=4.*atan(1.);
+  
   tper=&timepar[1];
 
   time=*tper;
@@ -153,6 +156,8 @@ void sensi_coor(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
       idisplacement=1;
     }else if(strcmp1(&objectset[i*405],"EIGENFREQUENCY")==0){
       ieigenfrequency=1;
+      fmin=2*pi*fei[1];
+      fmax=2*pi*fei[2];
     }else if(strcmp1(&objectset[i*405],"MODALSTRESS")==0){
       ieigenfrequency=1;
       modalstress=1;
@@ -760,6 +765,24 @@ void sensi_coor(double *co,ITG *nk,ITG **konp,ITG **ipkonp,char **lakonp,
       
     NNEW(dgdx,double,*ndesi**nobject);
 
+    /* Check for user defined lower frequency limit for the output */
+    if(ieigenfrequency==1){
+      if(fmin>-0.5){
+        if(fmin*fmin>d[iev]){
+	  continue;
+	}
+      }
+    }
+
+    /* Check for user defined upper frequency limit for the output */
+    if(ieigenfrequency==1){
+      if(fmax>-0.5){
+        if(fmax*fmax<d[iev]){
+	  continue;
+	}
+      }
+    }
+    
     /* Reading the "raw" sensititities */
 
     iread=0;

--- a/src/solidsections.f
+++ b/src/solidsections.f
@@ -44,6 +44,11 @@
       real*8 thicke(mi(3),*),thickness,pi,cs(18,*),xn(3),co(3,*),p(3),
      &     dd,xnor(*),orab(7,*)
 !
+#ifdef __INTEL_LLVM_COMPILER
+!     workaround for an issue with Intel ifx compilers in -O3 builds
+      volatile cs
+#endif
+!
       if((istep.gt.0).and.(irstrt(1).ge.0)) then
          write(*,*) '*ERROR reading *SOLID SECTION: *SOLID SECTION'
          write(*,*)'       should be placed before all step definitions'

--- a/test/compare
+++ b/test/compare
@@ -86,6 +86,18 @@ for i in *.inp; do
 	    mv substructure2.mtx substructure2.dat
 	fi
 
+    if [ $i = beammrlin_diff.inp ]
+	then
+	    rm -f beammrlin_diff.dat
+	    mv beammrlin_diff.mtx beammrlin_diff.dat
+	fi
+
+    if [ $i = beammrlin_same.inp ]
+	then
+	    rm -f beammrlin_same.dat
+	    mv beammrlin_same.mtx beammrlin_same.dat
+	fi
+
 #
 #       check whether the .dat and .dat.ref files exist
 #


### PR DESCRIPTION
commit 02ef6d73a7c8311df55d7709f3d7c2b2535886dc
Author: Christoph WOELFLE <Christoph.WOELFLE@mtu.de>
Date:   Mon Feb 9 11:09:12 2026 +0100

    Work around issue with Intel OneAPI LLVM based compilers in -O3 builds

    Tested with ifx 2024.02.0. Possibly narrow the preprocessor guard if
    the issue resolves in later versions.

commit 19a8701504c3b6ec39fda71e2eda36342df02ce2
Author: Franz-Josef Ertl <franz-josef.ertl@mtu.de>
Date:   Fri Feb 6 08:14:50 2026 +0100

    Ausgabe der angeforderten Frequenzen im *FREQUENCY step passt
    jetzt mit der Ausgabe der Sensitivitaeten bgzl. Frequenzen zusammen.
    (Vorher: es wurden immer die Sensitivitaeten von allen Frequenzen ausgegeben)

commit 7f61d52dcc2c5fcdb206c496dc2a07d4a3872afa
Author: BRUDER, Lukas <Lukas.BRUDER@mtu.de>
Date:   Mon Dec 22 10:32:12 2025 +0100

    Add special treatment for beammrlin test cases.